### PR TITLE
Added extra state, env var option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ all exposed ports are opened.
 
 ## How to use
 
+Add the layer to `layer.yaml`
+
+    includes: ['layer:docker-image']
+
+In your reactive file, set the state `docker-image.start` when the docker container is ready to start.
+This state can be used if the docker container needs environment variables for configuration. The charm's key-value store is used to pass this information to the docker-image layer. The key is `docker-image-env` and the value should be a dictionary.
+An example which adds mongodb connection info is:
+```
+@when('mongodb.available')
+def mongodb_connected(mongodb):
+    unitdata.kv().set('docker-image-env', 
+                      {'mongodb': mongodb.connection_string()})
+    set_state('docker-image.start')
+```
+    
 Deploy docker
 
     juju deploy cs:~tengu-team/docker-host
@@ -38,4 +53,5 @@ of [Ghent University](https://www.ugent.be) in Belgium. This software is used in
 frameworks and tools as easy as possible.
 
  - Gregory Van Seghbroeck <gregory.vanseghbroeck@ugent.be>
+
 


### PR DESCRIPTION
Added extra state `docker-image.start` which has to be set so the docker-image layer knows when to send the container request.

The docker-image layer will look in the charm's key-value store for a key `docker-image-env` which is expected to have a dictionary with environment variables. This dictionary is added to the container_request under the key 'env'.